### PR TITLE
Remove with-items as invalid reference

### DIFF
--- a/Magento_Checkout/layout/checkout_cart_index.xml
+++ b/Magento_Checkout/layout/checkout_cart_index.xml
@@ -10,8 +10,8 @@
     <body>
         <referenceContainer name="content">
             <referenceContainer name="checkout.cart.items">
-                <referenceContainer name="checkout.cart.container" htmlTag="div" htmlClass="cart-container row" before="-">
-                    <referenceContainer name="cart.summary" label="Cart Summary Container" htmlTag="div" htmlClass="cart-summary col-sm-3 pull-right" after="-">
+                <referenceContainer name="checkout.cart.container" htmlTag="div" htmlClass="cart-container row">
+                    <referenceContainer name="cart.summary" label="Cart Summary Container" htmlTag="div" htmlClass="cart-summary col-sm-3 pull-right">
                         <block class="Magento\Framework\View\Element\Template" name="checkout.cart.summary.title" before="-" template="Magento_Theme::text.phtml">
                             <arguments>
                                 <argument translate="true" name="text" xsi:type="string"></argument>

--- a/Magento_Checkout/layout/checkout_cart_index.xml
+++ b/Magento_Checkout/layout/checkout_cart_index.xml
@@ -9,7 +9,7 @@
     <update handle="checkout_cart_item_renderers"/>
     <body>
         <referenceContainer name="content">
-            <referenceContainer name="checkout.cart.items" as="with-items">
+            <referenceContainer name="checkout.cart.items">
                 <referenceContainer name="checkout.cart.container" htmlTag="div" htmlClass="cart-container row" before="-">
                     <referenceContainer name="cart.summary" label="Cart Summary Container" htmlTag="div" htmlClass="cart-summary col-sm-3 pull-right" after="-">
                         <block class="Magento\Framework\View\Element\Template" name="checkout.cart.summary.title" before="-" template="Magento_Theme::text.phtml">


### PR DESCRIPTION
Bugfix for error:

```
Cache file with merged layout: LAYOUT_frontend_STORE15_14e13260053f56644d576f1e487266f9a1 and handles default, checkout_cart_index: Please correct the XML data and try again. Element 'referenceContainer', attribute 'as': The attribute 'as' is not allowed
```